### PR TITLE
feat!(icon): integrate Iconify icons and update component usage

### DIFF
--- a/packages/Lumen/components/DocBox.vue
+++ b/packages/Lumen/components/DocBox.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
-import { BoxItem, isImage, isExternalLink } from '../types'
-
+import { BoxItem, isExternalLink } from '../types'
+import { Icon } from '@iconify/vue'
 const props = defineProps<{ items: BoxItem[] }>()
+
+// 用于检查是否为 Iconify 图标格式的辅助函数
+const isIconifyIcon = (icon: string) => icon.includes(':')
 </script>
 
 <template>
@@ -18,12 +21,13 @@ const props = defineProps<{ items: BoxItem[] }>()
       rel="noopener"
     >
       <template v-if="item.icon">
-        <img v-if="isImage(item.icon)" :src="item.icon" alt="Icon" class="icon" />
+        <Icon v-if="isIconifyIcon(item.icon)" :icon="item.icon" class="icon" :style="{ color: item.color }" />
         <i v-else :class="item.icon + ' icon'" :style="{ color: item.color }" alt="Icon"></i>
       </template>
-      <template v-else>
-        <img v-if="item.light" :src="item.light" alt="Icon" class="icon light-only" />
-        <img v-if="item.dark" :src="item.dark" alt="Icon" class="icon dark-only" />
+      <template v-else-if="item.img">
+        <img v-if="typeof item.img === 'object'" :src="item.img.light" alt="Icon" class="icon light-only" />
+        <img v-if="typeof item.img === 'object'" :src="item.img.dark" alt="Icon" class="icon dark-only" />
+        <img v-else :src="item.img" alt="Icon" class="icon" />
       </template>
       <span class="name">{{ item.name }}</span>
       <span v-if="item.tag" class="tag">{{ item.tag }}</span>

--- a/packages/Lumen/components/DocBox.vue
+++ b/packages/Lumen/components/DocBox.vue
@@ -1,10 +1,7 @@
 <script setup lang="ts">
-import { BoxItem, isExternalLink } from '../types'
-import { Icon } from '@iconify/vue'
-const props = defineProps<{ items: BoxItem[] }>()
+import { BoxItem, isExternalLink, isIconifyIcon, Icon } from '../types'
 
-// 用于检查是否为 Iconify 图标格式的辅助函数
-const isIconifyIcon = (icon: string) => icon.includes(':')
+const props = defineProps<{ items: BoxItem[] }>()
 </script>
 
 <template>
@@ -21,13 +18,13 @@ const isIconifyIcon = (icon: string) => icon.includes(':')
       rel="noopener"
     >
       <template v-if="item.icon">
-        <Icon v-if="isIconifyIcon(item.icon)" :icon="item.icon" class="icon" :style="{ color: item.color }" />
+        <Icon v-if="isIconifyIcon(item.icon)" :icon="item.icon" class="iconify" :style="{ color: item.color }" />
         <i v-else :class="item.icon + ' icon'" :style="{ color: item.color }" alt="Icon"></i>
       </template>
-      <template v-else-if="item.img">
-        <img v-if="typeof item.img === 'object'" :src="item.img.light" alt="Icon" class="icon light-only" />
-        <img v-if="typeof item.img === 'object'" :src="item.img.dark" alt="Icon" class="icon dark-only" />
-        <img v-else :src="item.img" alt="Icon" class="icon" />
+      <template v-else-if="item.image">
+        <img v-if="typeof item.image === 'object'" :src="item.image.light" alt="Icon" class="icon light-only" />
+        <img v-if="typeof item.image === 'object'" :src="item.image.dark" alt="Icon" class="icon dark-only" />
+        <img v-else :src="item.image" alt="Icon" class="icon" />
       </template>
       <span class="name">{{ item.name }}</span>
       <span v-if="item.tag" class="tag">{{ item.tag }}</span>
@@ -99,6 +96,15 @@ const isIconifyIcon = (icon: string) => icon.includes(':')
 .icon {
   height: 1em;
   font-size: 2em;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--vp-c-text-1);
+}
+
+.iconify {
+  font-size: 2.4em;
+  margin: 0 -0.1em 0 -0.1em;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/packages/Lumen/components/DocBoxCube.vue
+++ b/packages/Lumen/components/DocBoxCube.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { BoxCubeItem, isImage, isExternalLink } from '../types'
+import { BoxCubeItem, isExternalLink, isIconifyIcon, Icon } from '../types'
 
 const props = defineProps<{ items: BoxCubeItem[] }>()
 </script>
@@ -18,12 +18,13 @@ const props = defineProps<{ items: BoxCubeItem[] }>()
       rel="noopener"
     >
       <template v-if="item.icon">
-        <img v-if="isImage(item.icon)" :src="item.icon" alt="Icon" class="icon" />
+        <Icon v-if="isIconifyIcon(item.icon)" :icon="item.icon" class="iconify" :style="{ color: item.color }" />
         <i v-else :class="item.icon + ' icon'" :style="{ color: item.color }" alt="Icon"></i>
       </template>
-      <template v-else>
-        <img v-if="item.light" :src="item.light" alt="Icon" class="icon light-only" />
-        <img v-if="item.dark" :src="item.dark" alt="Icon" class="icon dark-only" />
+      <template v-else-if="item.image">
+        <img v-if="typeof item.image === 'object'" :src="item.image.light" alt="Icon" class="icon light-only" />
+        <img v-if="typeof item.image === 'object'" :src="item.image.dark" alt="Icon" class="icon dark-only" />
+        <img v-else :src="item.image" alt="Icon" class="icon" />
       </template>
       <span class="name">{{ item.name }}</span>
       <span class="desc">{{ item.desc }}</span>
@@ -79,7 +80,13 @@ const props = defineProps<{ items: BoxCubeItem[] }>()
   .icon {
     margin-top: -1rem;
     font-size: 2.5em;
-    width: 2.5rem;
+    height: 2.5rem;
+    color: var(--vp-c-text-1);
+  }
+
+  .iconify {
+    margin-top: -1rem;
+    font-size: 3em;
     color: var(--vp-c-text-1);
   }
 

--- a/packages/Lumen/components/DocLinks.vue
+++ b/packages/Lumen/components/DocLinks.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
-import { LinkItem, isImage, isExternalLink } from '../types'
+import { LinkItem, isExternalLink, isIconifyIcon, Icon } from '../types'
 
 const props = defineProps<{ items: LinkItem[] }>()
 </script>
 
 <template>
-  <!-- 渲染包含多个链接项的容器 -->
   <div class="container">
-    <!-- 遍历 `items` 数组，渲染每个链接项 -->
     <a
       v-for="item in props.items"
       :key="item.name"
@@ -17,18 +15,18 @@ const props = defineProps<{ items: LinkItem[] }>()
       class="link"
       rel="noopener"
     >
-      <!-- 渲染图标 -->
       <template v-if="item.icon">
-        <img v-if="isImage(item.icon)" :src="item.icon" alt="Icon" class="icon" />
+        <Icon v-if="isIconifyIcon(item.icon)" :icon="item.icon" class="iconify" :style="{ color: item.color }" />
         <i v-else :class="item.icon + ' icon'" :style="{ color: item.color }"></i>
       </template>
-      <template v-else>
-        <img v-if="item.light" :src="item.light" alt="Icon" class="icon light-only" />
-        <img v-if="item.dark" :src="item.dark" alt="Icon" class="icon dark-only" />
-        <i v-if="!item.light && !item.dark" class="fas fa-arrow-up-right-from-square fa-icon" alt="Icon"></i>
+      <template v-else-if="item.image">
+        <img v-if="typeof item.image === 'object'" :src="item.image.light" alt="Icon" class="icon light-only" />
+        <img v-if="typeof item.image === 'object'" :src="item.image.dark" alt="Icon" class="icon dark-only" />
+        <img v-else :src="item.image" alt="Icon" class="icon" />
       </template>
-
-      <!-- 渲染链接项的名称和描述 -->
+      <template v-else>
+        <i class="fas fa-arrow-up-right-from-square fa-icon" alt="Icon"></i>
+      </template>
       <div class="text-content">
         <span class="name">{{ item.name }}</span>
         <span v-if="item.desc" class="desc">{{ item.desc }}</span>
@@ -68,11 +66,13 @@ const props = defineProps<{ items: LinkItem[] }>()
   }
 }
 
-.icon {
+.icon,
+.iconify {
   width: 2.5rem;
   font-size: 2.5em;
   margin-left: 1.5rem;
 }
+
 .fa-icon {
   width: 2rem;
   font-size: 1.5em;

--- a/packages/Lumen/components/HomeFooter.vue
+++ b/packages/Lumen/components/HomeFooter.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import { FooterData, useWindowWidth } from '../types'
+import { FooterData, useWindowWidth, isIconifyIcon, Icon } from '../types'
 
 // 使用 defineProps 定义属性
 const props = defineProps<{ Footer_Data: FooterData }>()
@@ -33,7 +33,16 @@ const isLargeScreen = computed(() => windowWidth.value! > 768)
     <div class="ff">
       <div class="sc" v-for="(section, index) in props.Footer_Data.group || []" :key="index">
         <div class="st" @click="toggleSection(index)">
-          <i v-if="section.icon" :class="section.icon" :style="section.style"></i>
+          <template v-if="section.icon">
+            <i v-if="section.icon" :class="section.icon" :style="{ color: section.style }"></i>
+            <Icon
+              v-if="isIconifyIcon(section.icon)"
+              :icon="section.icon"
+              class="iconify"
+              :style="{ color: section.style }"
+            />
+          </template>
+
           {{ section.title }}
           <button class="toggle-button">
             {{ openSectionIndex === index ? '−' : '+' }}
@@ -41,7 +50,10 @@ const isLargeScreen = computed(() => windowWidth.value! > 768)
         </div>
         <ul v-if="openSectionIndex === index || isLargeScreen">
           <li v-for="(link, idx) in section.links" :key="idx">
-            <i v-if="link.icon" :class="link.icon" :style="link.style"></i>
+            <template v-if="link.icon">
+              <i v-if="link.icon" :class="link.icon" :style="{ color: link.style }"></i>
+              <Icon v-if="isIconifyIcon(link.icon)" :icon="link.icon" :style="{ color: link.style }" />
+            </template>
             <a
               :class="{ 'external-link': !link.internal && !section.internal }"
               :target="link.internal || section.internal ? '_self' : '_blank'"
@@ -60,13 +72,13 @@ const isLargeScreen = computed(() => windowWidth.value! > 768)
     <!-- 底部信息栏 -->
     <div class="flex" v-if="props.Footer_Data.beian?.icp || props.Footer_Data.beian?.police">
       <span v-if="props.Footer_Data.beian?.icp">
-        <i class="fas fa-earth-americas"></i>
+        <Icon v-if="props.Footer_Data.beian?.showIcon" icon="fluent-color:globe-shield-48" />
         <a target="_blank" rel="noopener" href="https://beian.miit.gov.cn/" title="ICP备案">
           {{ props.Footer_Data.beian.icp }}
         </a>
       </span>
       <span v-if="props.Footer_Data.beian?.police">
-        <i class="fas fa-shield"></i>
+        <Icon v-if="props.Footer_Data.beian?.showIcon" icon="fluent-color:shield-checkmark-48" />
         <a target="_blank" rel="noopener" href="https://beian.mps.gov.cn/" title="公安备案">
           {{ props.Footer_Data.beian.police }}
         </a>
@@ -74,7 +86,7 @@ const isLargeScreen = computed(() => windowWidth.value! > 768)
     </div>
     <div class="flex" v-if="props.Footer_Data.author?.name">
       <span>
-        <i class="far fa-copyright"></i>{{ new Date().getFullYear() }}
+        <Icon icon="ri:copyright-line" />{{ new Date().getFullYear() }}
         <a target="_blank" rel="noopener" title="GitHub" :href="props.Footer_Data.author?.link">
           {{ props.Footer_Data.author?.name }}</a
         >. All Rights Reserved.
@@ -130,6 +142,12 @@ i {
     color: var(--vp-c-text-3);
     transform: rotate(-45deg);
   }
+}
+
+.iconify {
+  position: relative;
+  display: inline-block;
+  margin: 0 0.25rem -0.1rem 0;
 }
 
 .ba {
@@ -199,6 +217,10 @@ i {
     padding: 0.5rem 0;
     i {
       margin-right: 1rem;
+    }
+    .iconify {
+      margin-right: 1rem;
+      margin-left: -1rem;
     }
     .toggle-button {
       margin-left: auto;

--- a/packages/Lumen/package.json
+++ b/packages/Lumen/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.6.0",
+    "@iconify/vue": "^4.1.2",
     "bumpp": "^9.8.1",
     "sass": "^1.80.6",
     "twikoo": "^1.6.39",

--- a/packages/Lumen/types/index.ts
+++ b/packages/Lumen/types/index.ts
@@ -9,6 +9,7 @@ export { default as HomeUnderline } from '../components/HomeUnderline.vue'
 export { default as Twikoo } from '../components/DocTwikoo.vue'
 export { default as ShareButton } from '../components/ShareButton.vue'
 
+export { Icon } from '@iconify/vue'
 export * from './types'
 export * from './utils'
 

--- a/packages/Lumen/types/types.ts
+++ b/packages/Lumen/types/types.ts
@@ -22,13 +22,12 @@ export interface BoxCubeItem {
 
 // DocBox
 export interface BoxItem {
-  link: string // 链接项的链接地址。
-  icon: string // 链接项的图标地址或类名。
-  name: string // 链接项的名称。
-  tag?: string // 链接项的标签（可选）。
-  light?: string // 浅色模式下的图标 URL（可选）。
-  dark?: string // 深色模式下的图标 URL（可选）。
-  color?: string // 图标的颜色（可选）。
+  name: string
+  link: string
+  tag?: string
+  color?: string
+  icon?: string // 对于 `iconify` 图标，可以是字符串
+  img?: string | { light: string; dark: string } // 支持单一图片地址或包含 light 和 dark 两种模式的对象
 }
 
 // DocAsideLogo

--- a/packages/Lumen/types/types.ts
+++ b/packages/Lumen/types/types.ts
@@ -72,6 +72,7 @@ export interface Group {
 export interface Beian {
   icp?: string // ICP 备案号（可选）
   police?: string // 公安备案号（可选）
+  showIcon?: boolean // 图标（可选）
 }
 
 export interface Author {

--- a/packages/Lumen/types/types.ts
+++ b/packages/Lumen/types/types.ts
@@ -4,20 +4,18 @@ export interface LinkItem {
   desc?: string // 链接项的描述（可选）
   link: string // 链接项的 URL
   color?: string | null // 图标的颜色（可选）
-  icon?: string | null // 图标的 URL 或类名（可选）
-  light?: string | null // 浅色模式下的图标 URL（可选）
-  dark?: string | null // 深色模式下的图标 URL（可选）
+  icon?: string | null // 对于 `iconify`或者 `fortawesome` 图标
+  image?: string | { light: string; dark: string } // 支持单一图片地址或包含 light 和 dark 两种模式的对象
 }
 
 //  DocBoxCube
 export interface BoxCubeItem {
-  icon: string // 图标的 URL 或类名。
   name: string // 项目的名称。
   link: string // 项目的链接。
   desc?: string // 项目的描述（可选）。
   color?: string // 图标的颜色（可选）。
-  light?: string // 浅色模式下的图标 URL（可选）。
-  dark?: string // 深色模式下的图标 URL（可选）。
+  icon?: string | null // 对于 `iconify`或者 `fortawesome` 图标
+  image?: string | { light: string; dark: string } // 支持单一图片地址或包含 light 和 dark 两种模式的对象
 }
 
 // DocBox
@@ -26,8 +24,8 @@ export interface BoxItem {
   link: string
   tag?: string
   color?: string
-  icon?: string // 对于 `iconify` 图标，可以是字符串
-  img?: string | { light: string; dark: string } // 支持单一图片地址或包含 light 和 dark 两种模式的对象
+  icon?: string // 对于 `iconify`或者 `fortawesome` 图标
+  image?: string | { light: string; dark: string } // 支持单一图片地址或包含 light 和 dark 两种模式的对象
 }
 
 // DocAsideLogo

--- a/packages/Lumen/types/utils.ts
+++ b/packages/Lumen/types/utils.ts
@@ -13,23 +13,13 @@ export const usePrelink = (): Prelink | undefined => {
 }
 
 /**
- * 判断给定的 URL 是否为图像文件。
+ * 检查给定的图标字符串是否为 Iconify 格式。
+ * Iconify 图标通常包含一个冒号（例如 "mdi:home"）。
  *
- * @param {string} url - 要判断的 URL。
- * @returns {boolean} - 如果 URL 是图像文件，则返回 `true`，否则返回 `false`。
- *
- * 该函数首先检查 URL 是否以 `http` 或 `https` 开头，并且是否包含有效的图像文件后缀（如 png, jpeg, gif 等）。
- * 如果 URL 没有后缀，但以 `http` 或 `https` 开头，则也视为有效的图像链接。
+ * @param icon - 要检查的图标字符串。
+ * @returns 如果图标是 Iconify 格式，则返回 `true`，否则返回 `false`。
  */
-export const isImage = (url: string): boolean => {
-  // 检查 URL 是否包含合法的图像文件后缀
-  const hasValidExtension = /\.(png|jpe?g|gif|svg|webp|bmp|tif?f|tiff|ico|avif)(\?.*)?$/i.test(url)
-  // 检查 URL 是否以 http 或 https 开头
-  const isHttpOrHttps = /^https?:\/\//i.test(url)
-
-  // 如果包含有效后缀，或没有后缀但以 http 或 https 开头，则返回 true
-  return hasValidExtension || (isHttpOrHttps && !/\.(\w+)$/.test(url))
-}
+export const isIconifyIcon = (icon: string): boolean => icon.includes(':')
 
 /**
  * 判断给定的链接是否是外部链接。

--- a/packages/docs/.vitepress/data/FooterData.ts
+++ b/packages/docs/.vitepress/data/FooterData.ts
@@ -3,7 +3,8 @@ import type { FooterData } from '@theojs/lumen'
 export const Footer_Data: FooterData = {
   beian: {
     icp: '鄂ICP备2024060426号',
-    police: '粤公网安备44200102445449号'
+    police: '粤公网安备44200102445449号',
+    showIcon: true
   },
   author: {
     name: 'Theo-Messi',
@@ -42,8 +43,8 @@ export const Footer_Data: FooterData = {
       links: [
         {
           name: '青云梯',
-          icon: 'fab fa-gripfire',
-          style: 'color: rgba(255, 87, 51, 1)',
+          icon: 'el:fire',
+          style: 'rgba(255, 87, 51, 1)',
           href: 'https://ivt01.qytaff.cc/register?aff=jjgD79Jd'
         },
         { name: '银河录像局', href: 'https://nf.video/kaIuE' },

--- a/packages/docs/guide/DocTwikoo.md
+++ b/packages/docs/guide/DocTwikoo.md
@@ -6,7 +6,7 @@ title: Twikoo 评论
   :items="[
     {
       name: '如何部署请查看 Twikoo 文档',
-      icon: 'https://twikoo.js.org/twikoo-logo-home.png',
+      image: 'https://twikoo.js.org/twikoo-logo-home.png',
       desc: '一个简洁、安全、免费的静态网站评论系统。',
       link: 'https://twikoo.js.org/quick-start.html'
     }

--- a/packages/docs/guide/HomeFooter.md
+++ b/packages/docs/guide/HomeFooter.md
@@ -14,15 +14,15 @@ title: 页脚配置
 import type { FooterData } from '@theojs/lumen'
 
 export const Footer_Data: FooterData = {
-  beian: { icp: '备案号', police: '公网安备号' },
+  beian: { icp: '备案号', police: '公网安备号', showIcon: true },
   author: { name: 'Theo', link: 'https://' },
   group: [
     {
       title: '外部链接',
-      icon: 'fas fa-link', // Font Awesome 图标类名 具体查看:https://fontawesome.com/
-      style: 'color: rgba(255, 87, 51, 1)',
+      icon: 'fas fa-link', // `iconify`或者 `fortawesome` 图标
+      style: 'rgba(255, 87, 51, 1)',
       links: [
-        { name: '示例1', href: 'https://' },
+        { name: '示例1', href: 'https://', icon: 'fas fa-book' },
         { name: '示例2', href: 'https://' }
       ]
     },
@@ -30,7 +30,7 @@ export const Footer_Data: FooterData = {
       title: '内部链接',
       internal: true, // `internal`默认为 false , 为 true 时不显示外部链接图标
       icon: 'fas fa-link',
-      style: 'color: rgba(255, 87, 51, 1)',
+      style: 'rgba(255, 87, 51, 1)',
       links: [
         { name: '示例1', icon: 'fas fa-book', href: '/docs' },
         { name: '示例2', href: '/page' }
@@ -67,22 +67,23 @@ export default {
 
 ## 数据接口说明
 
-| 字段                                 | 类型    | 描述                                                              |
-| ------------------------------------ | ------- | ----------------------------------------------------------------- |
-| **group**?                           | Array   | <Badge type="tip" text="可选" /> 链接分组列表。                   |
-| ├─ icon?                             | string  | <Badge type="tip" text="可选" /> 图标                             |
-| ├─ style?                            | string  | <Badge type="tip" text="可选" /> 图标样式                         |
-| ├─ title                             | string  | 分组标题。                                                        |
-| ├─ internal?                         | boolean | <Badge type="tip" text="可选" /> 该组是否为内部链接，默认 `false` |
-| └─ links                             | Array   | 分组中的链接列表。                                                |
-| &nbsp;&nbsp;&nbsp;&nbsp;├─ icon?     | string  | <Badge type="tip" text="可选" /> 链接图标                         |
-| &nbsp;&nbsp;&nbsp;&nbsp;├─ style?    | string  | <Badge type="tip" text="可选" /> 链接样式                         |
-| &nbsp;&nbsp;&nbsp;&nbsp;├─ name      | string  | 链接名称。                                                        |
-| &nbsp;&nbsp;&nbsp;&nbsp;├─ href      | string  | 链接地址。                                                        |
-| &nbsp;&nbsp;&nbsp;&nbsp;└─ internal? | boolean | <Badge type="tip" text="可选" /> 是否为内部链接，默认 `false`     |
-| **beian**?                           | object  | <Badge type="tip" text="可选" /> 备案信息                         |
-| ├─ icp?                              | string  | <Badge type="tip" text="可选" /> ICP 备案号                       |
-| └─ police?                           | string  | <Badge type="tip" text="可选" /> 公安备案号                       |
-| **author**?                          | object  | <Badge type="tip" text="可选" /> 作者信息                         |
-| ├─ name?                             | string  | <Badge type="tip" text="可选" /> 作者姓名                         |
-| └─ link?                             | string  | <Badge type="tip" text="可选" /> 作者链接                         |
+| 字段                                 | 类型    | 描述                                                                                                                                             |
+| ------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **group**?                           | Array   | <Badge type="tip" text="可选" /> 链接分组列表。                                                                                                  |
+| ├─ icon?                             | string  | <Badge type="tip" text="可选" /> [iconify](https://icon-sets.iconify.design/) 或者 [fortawesome](https://fontawesome.com/search?o=r&m=free) 图标 |
+| ├─ style?                            | string  | <Badge type="tip" text="可选" /> 图标样式                                                                                                        |
+| ├─ title                             | string  | 分组标题。                                                                                                                                       |
+| ├─ internal?                         | boolean | <Badge type="tip" text="可选" /> 该组是否为内部链接，默认 `false`                                                                                |
+| └─ links                             | Array   | 分组中的链接列表。                                                                                                                               |
+| &nbsp;&nbsp;&nbsp;&nbsp;├─ icon?     | string  | <Badge type="tip" text="可选" /> [iconify](https://icon-sets.iconify.design/) 或者 [fortawesome](https://fontawesome.com/search?o=r&m=free) 图标 |
+| &nbsp;&nbsp;&nbsp;&nbsp;├─ style?    | string  | <Badge type="tip" text="可选" /> 图标样式                                                                                                        |
+| &nbsp;&nbsp;&nbsp;&nbsp;├─ name      | string  | 链接名称。                                                                                                                                       |
+| &nbsp;&nbsp;&nbsp;&nbsp;├─ href      | string  | 链接地址。                                                                                                                                       |
+| &nbsp;&nbsp;&nbsp;&nbsp;└─ internal? | boolean | <Badge type="tip" text="可选" /> 是否为内部链接，默认 `false`                                                                                    |
+| **beian**?                           | object  | <Badge type="tip" text="可选" /> 备案信息                                                                                                        |
+| ├─ icp?                              | string  | <Badge type="tip" text="可选" /> ICP 备案号                                                                                                      |
+| ├─ police?                           | string  | <Badge type="tip" text="可选" /> 公安备案号                                                                                                      |
+| └─ showIcon?                         | boolean | <Badge type="tip" text="可选" /> 备案图标是否显示，默认 `false`                                                                                  |
+| **author**?                          | object  | <Badge type="tip" text="可选" /> 作者信息                                                                                                        |
+| ├─ name?                             | string  | <Badge type="tip" text="可选" /> 作者姓名                                                                                                        |
+| └─ link?                             | string  | <Badge type="tip" text="可选" /> 作者链接                                                                                                        |

--- a/packages/docs/guide/LinkCard.md
+++ b/packages/docs/guide/LinkCard.md
@@ -20,6 +20,12 @@ export default {
 
 ```
 
+::: tip `icon` 属性支持使用 `FontAwesome` 和 `Iconify` 图标。
+
+- **FontAwesome**: 使用格式为 `icon: 'fab fa-vuejs'`。查看更多图标，请访问 [FontAwesome](https://fontawesome.com/search?o=r&m=free)。
+- **Iconify**: 使用格式为 `icon: 'vscode-icons:file-type-vue'`。查看更多图标，请访问 [Iconify](https://icon-sets.iconify.design/)。
+  :::
+
 ## Box
 
 ### 示例
@@ -29,35 +35,24 @@ export default {
 ```vue
 <Box
   :items="[
-    //使用FontAwesome图标 + 颜色
-    { name: 'Vue.js', link: '', icon: 'fab fa-vuejs', color: '#4FC08D' },
-    //使用FontAwesome图标 + 标签
-    { name: 'GitHub', link: '', icon: 'fab fa-github', tag: 'Github' },
-    //使用FontAwesome图标 + 标签 + 颜色
+    //FontAwesome图标
+    { name: 'fontawesome', link: '', icon: 'fas fa-font-awesome', color: '#538DD7' },
+    //iconify图标
+    { name: 'iconify', link: '', icon: 'line-md:iconify1', color: '#1769AA' },
+    //图片
     {
       name: '支付宝',
       link: 'https://i.theojs.cn/docs/202405201752089.jpg',
-      icon: 'fab fa-alipay',
-      color: '#00a1e9',
-      tag: '打赏'
+      image: 'https://i.theojs.cn/logo/alipay.svg'
     },
-    {
-      name: '微信',
-      link: 'https://i.theojs.cn/docs/202405201752087.jpg',
-      icon: 'fab fa-weixin',
-      color: '#2ca83c',
-      tag: '打赏'
-    },
-    //使用自定义图标 + 标签
-    { name: 'GitHub', link: '', icon: 'https://i.theojs.cn/logo/github.svg', tag: 'Github' },
-    //使用自定义图标 + 深浅模式 + 标签
+    //深浅模式的图片
     {
       name: 'GitHub',
       link: '',
-      light: 'https://i.theojs.cn/logo/github.svg',
-      dark: 'https://i.theojs.cn/logo/github-dark.svg',
-      tag: 'Github'
-    }
+      image: { light: 'https://i.theojs.cn/logo/github.svg', dark: 'https://i.theojs.cn/logo/github-dark.svg' }
+    },
+    //标签
+    { name: 'Vue', link: '', icon: 'vscode-icons:file-type-vue', tag: 'vuejs' }
   ]"
 />
 ```
@@ -65,60 +60,38 @@ export default {
 **输出**
 
 <Box
-:items="[
-    {
-    name: 'Home',
-    link: '/home',
-    icon: 'mdi:home',
-    color: '#4caf50',
-  },
-    //使用FontAwesome图标 + 颜色
-    { name: 'Vue.js', link: '', icon: 'fab fa-vuejs', color: '#4FC08D' },
-    //使用FontAwesome图标 + 标签
-    { name: 'GitHub', link: '', icon: 'fab fa-github', tag: 'Github' },
-    //使用FontAwesome图标 + 标签 + 颜色
+  :items="[
+    //FontAwesome图标
+    { name: 'fontawesome', link: '', icon: 'fas fa-font-awesome', color: '#538DD7' },
+    //iconify图标
+    { name: 'iconify', link: '', icon: 'line-md:iconify1', color: '#1769AA' },
+    //图片
     {
       name: '支付宝',
       link: 'https://i.theojs.cn/docs/202405201752089.jpg',
-      icon: 'fab fa-alipay',
-      color: '#00a1e9',
-      tag: '打赏'
+      image: 'https://i.theojs.cn/logo/alipay.svg'
     },
-    {
-      name: '微信',
-      link: 'https://i.theojs.cn/docs/202405201752087.jpg',
-      icon: 'fab fa-weixin',
-      color: '#2ca83c',
-      tag: '打赏'
-    },
-    //使用自定义图标 + 标签
+    //深浅模式的图片
     {
       name: 'GitHub',
       link: '',
-      img: 'https://i.theojs.cn/logo/github.svg',
-      tag: 'Github'
+      image: { light: 'https://i.theojs.cn/logo/github.svg', dark: 'https://i.theojs.cn/logo/github-dark.svg' }
     },
-    //使用自定义图标 + 深浅模式 + 标签
-    {
-      name: 'GitHub',
-      link: '',
-      img: { light: 'https://i.theojs.cn/logo/github.svg', dark: 'https://i.theojs.cn/logo/github-dark.svg' },
-      tag: 'Github'
-    }
-]"
+    //标签
+    { name: 'Vue', link: '', icon: 'vscode-icons:file-type-vue', tag: 'vuejs' }
+  ]"
 />
 
 ### 参数说明
 
-| 字段       | 类型   | 描述                                                    |
-| ---------- | ------ | ------------------------------------------------------- |
-| **link**   | string | 链接项的链接地址。                                      |
-| **icon**   | string | 链接项的图标地址或类名。                                |
-| **name**   | string | 链接项的名称。                                          |
-| **tag?**   | string | <Badge type="tip" text="可选" /> 链接项的标签。         |
-| **light?** | string | <Badge type="tip" text="可选" /> 浅色模式下的图标 URL。 |
-| **dark?**  | string | <Badge type="tip" text="可选" /> 深色模式下的图标 URL。 |
-| **color?** | string | <Badge type="tip" text="可选" /> 图标的颜色。           |
+|   字段    |                     类型                      | 描述                                                                                                                                             |
+| :-------: | :-------------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **name**  |                   `string`                    | 链接项的名称。                                                                                                                                   |
+| **link**  |                   `string`                    | 链接项的链接地址。                                                                                                                               |
+|  **tag**  |                   `string`                    | <Badge type="tip" text="可选" /> 链接项的标签。                                                                                                  |
+| **color** |                   `string`                    | <Badge type="tip" text="可选" /> 图标的颜色。                                                                                                    |
+| **icon**  |                   `string`                    | <Badge type="tip" text="可选" /> [iconify](https://icon-sets.iconify.design/) 或者 [fortawesome](https://fontawesome.com/search?o=r&m=free) 图标 |
+| **image** | `string` \| `{ light: string; dark: string }` | <Badge type="tip" text="可选" /> 支持单一图片地址或包含 light 和 dark 两种模式的对象                                                             |
 
 ## Links
 
@@ -129,18 +102,21 @@ export default {
 ```vue
 <Links
   :items="[
-    // 使用FontAwesome图标 + 颜色
-    { name: '支付宝', link: 'https://www.alipay.com', icon: 'fab fa-alipay', color: '#00a1e9' },
-    { name: '微信支付', link: 'https://pay.weixin.qq.com', icon: 'fab fa-weixin', color: '#2ca83c' },
-    // 使用自定义图标
-    { name: 'GitHub', link: 'https://github.com', icon: 'https://i.theojs.cn/logo/github.svg' },
-    // 使用自定义图标 + 深浅模式
+    //FontAwesome图标
+    { name: 'fontawesome', link: '', icon: 'fas fa-font-awesome', color: '#538DD7' },
+    //iconify图标
+    { name: 'iconify', link: '', icon: 'line-md:iconify1', color: '#1769AA' },
+    //图片
+    {
+      name: '支付宝',
+      link: 'https://i.theojs.cn/docs/202405201752089.jpg',
+      image: 'https://i.theojs.cn/logo/alipay.svg'
+    },
+    //深浅模式的图片
     {
       name: 'GitHub',
-      link: 'https://github.com',
-      light: 'https://i.theojs.cn/logo/github.svg',
-      dark: 'https://i.theojs.cn/logo/github-dark.svg',
-      desc: '支持深浅模式切换'
+      link: '',
+      image: { light: 'https://i.theojs.cn/logo/github.svg', dark: 'https://i.theojs.cn/logo/github-dark.svg' }
     },
     // 不使用图标 + 描述
     { name: 'Google', link: 'https://www.google.com', desc: '全球最大的搜索引擎' }
@@ -151,18 +127,21 @@ export default {
 **输出**
 <Links
   :items="[
-    // 使用FontAwesome图标 + 颜色
-    { name: '支付宝', link: 'https://www.alipay.com', icon: 'fab fa-alipay', color: '#00a1e9' },
-    { name: '微信支付', link: 'https://pay.weixin.qq.com', icon: 'fab fa-weixin', color: '#2ca83c' },
-    // 使用自定义图标
-    { name: 'GitHub', link: 'https://github.com', icon: 'https://i.theojs.cn/logo/github.svg' },
-    // 使用自定义图标 + 深浅模式
+    //FontAwesome图标
+    { name: 'fontawesome', link: '', icon: 'fas fa-font-awesome', color: '#538DD7' },
+    //iconify图标
+    { name: 'iconify', link: '', icon: 'line-md:iconify1', color: '#1769AA' },
+    //图片
+    {
+      name: '支付宝',
+      link: 'https://i.theojs.cn/docs/202405201752089.jpg',
+      image: 'https://i.theojs.cn/logo/alipay.svg'
+    },
+    //深浅模式的图片
     {
       name: 'GitHub',
-      link: 'https://github.com',
-      light: 'https://i.theojs.cn/logo/github.svg',
-      dark: 'https://i.theojs.cn/logo/github-dark.svg',
-      desc: '支持深浅模式切换'
+      link: '',
+      image: { light: 'https://i.theojs.cn/logo/github.svg', dark: 'https://i.theojs.cn/logo/github-dark.svg' }
     },
     // 不使用图标 + 描述
     { name: 'Google', link: 'https://www.google.com', desc: '全球最大的搜索引擎' }
@@ -171,15 +150,14 @@ export default {
 
 ### 参数说明
 
-| 字段       | 类型   | 描述                                                    |
-| ---------- | ------ | ------------------------------------------------------- |
-| **name**   | string | 链接项的名称。                                          |
-| **link**   | string | 链接项的 URL。                                          |
-| **color?** | string | <Badge type="tip" text="可选" /> 图标的颜色。           |
-| **icon?**  | string | <Badge type="tip" text="可选" /> 图标的 URL 或类名。    |
-| **light?** | string | <Badge type="tip" text="可选" /> 浅色模式下的图标 URL。 |
-| **dark?**  | string | <Badge type="tip" text="可选" /> 深色模式下的图标 URL。 |
-| **desc?**  | string | <Badge type="tip" text="可选" /> 链接项的描述信息。     |
+|   字段    |                     类型                      | 描述                                                                                                                                             |
+| :-------: | :-------------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **name**  |                   `string`                    | 链接项的名称。                                                                                                                                   |
+| **desc**  |                   `string`                    | <Badge type="tip" text="可选" /> 链接项的描述信息。                                                                                              |
+| **link**  |                   `string`                    | 链接项的 URL。                                                                                                                                   |
+| **color** |                   `string`                    | <Badge type="tip" text="可选" /> 图标的颜色。                                                                                                    |
+| **icon**  |                   `string`                    | <Badge type="tip" text="可选" /> [iconify](https://icon-sets.iconify.design/) 或者 [fortawesome](https://fontawesome.com/search?o=r&m=free) 图标 |
+| **image** | `string` \| `{ light: string; dark: string }` | <Badge type="tip" text="可选" /> 支持单一图片地址或包含 light 和 dark 两种模式的对象                                                             |
 
 ## BoxCube
 
@@ -190,20 +168,24 @@ export default {
 ```vue
 <BoxCube
   :items="[
-    //使用FontAwesome图标
-    { name: 'Github', link: '', icon: 'fab fa-github' },
-    //使用FontAwesome图标 + 副标题
-    { name: 'Vue.js', link: '', icon: 'fab fa-vuejs', desc: 'v3.4.31' },
-    //使用自定义图标+副标题
-    { name: 'Node.js', link: '', icon: 'https://i.theojs.cn/logo/nodejs.svg', desc: 'v20.15.0' },
-    //使用自定义图标+深浅模式+副标题
+    //FontAwesome图标
+    { name: 'fontawesome', link: '', icon: 'fas fa-font-awesome', color: '#538DD7' },
+    //iconify图标
+    { name: 'iconify', link: '', icon: 'line-md:iconify1', color: '#1769AA' },
+    //图片
     {
-      name: 'Github',
+      name: '支付宝',
+      link: 'https://i.theojs.cn/docs/202405201752089.jpg',
+      image: 'https://i.theojs.cn/logo/alipay.svg'
+    },
+    //深浅模式的图片
+    {
+      name: 'GitHub',
       link: '',
-      light: 'https://i.theojs.cn/logo/github.svg',
-      dark: 'https://i.theojs.cn/logo/github-dark.svg',
-      desc: 'v20.15.0'
-    }
+      image: { light: 'https://i.theojs.cn/logo/github.svg', dark: 'https://i.theojs.cn/logo/github-dark.svg' }
+    },
+    //描述
+    { name: 'Vue.js', link: '', icon: 'fab fa-vuejs', desc: 'v3.4.31' }
   ]"
 />
 ```
@@ -211,36 +193,34 @@ export default {
 **输出**
 <BoxCube
   :items="[
-    //使用FontAwesome图标
-    { name: 'Github', link: '', icon: 'fab fa-github' },
-    //使用FontAwesome图标 + 副标题
-    { name: 'Vue.js', link: '', icon: 'fab fa-vuejs', desc: 'v3.4.31' },
-    //使用自定义图标+副标题
+    //FontAwesome图标
+    { name: 'fontawesome', link: '', icon: 'fas fa-font-awesome', color: '#538DD7' },
+    //iconify图标
+    { name: 'iconify', link: '', icon: 'line-md:iconify1', color: '#1769AA' },
+    //图片
     {
-      name: 'Node.js',
-      link: '',
-      icon: 'https://i.theojs.cn/logo/nodejs.svg',
-      desc: 'v20.15.0'
+      name: '支付宝',
+      link: 'https://i.theojs.cn/docs/202405201752089.jpg',
+      image: 'https://i.theojs.cn/logo/alipay.svg'
     },
-    //使用自定义图标+深浅模式+副标题
+    //深浅模式的图片
     {
-      name: 'Github',
+      name: 'GitHub',
       link: '',
-      light: 'https://i.theojs.cn/logo/github.svg',
-      dark: 'https://i.theojs.cn/logo/github-dark.svg',
-      desc: 'v20.15.0'
-    }
+      image: { light: 'https://i.theojs.cn/logo/github.svg', dark: 'https://i.theojs.cn/logo/github-dark.svg' }
+    },
+    //描述
+    { name: 'Vue.js', link: '', icon: 'fab fa-vuejs', desc: 'v3.4.31' }
   ]"
 />
 
 ## 参数说明
 
-| 字段       | 类型   | 描述                                                    |
-| ---------- | ------ | ------------------------------------------------------- |
-| **icon**   | string | 图标的 URL 或类名。                                     |
-| **name**   | string | 项目的名称。                                            |
-| **link**   | string | 项目的链接。                                            |
-| **desc?**  | string | <Badge type="tip" text="可选" /> 项目的描述。           |
-| **color?** | string | <Badge type="tip" text="可选" /> 图标的颜色。           |
-| **light?** | string | <Badge type="tip" text="可选" /> 浅色模式下的图标 URL。 |
-| **dark?**  | string | <Badge type="tip" text="可选" /> 深色模式下的图标 URL。 |
+|   字段    |                     类型                      | 描述                                                                                                                                             |
+| :-------: | :-------------------------------------------: | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **name**  |                   `string`                    | 项目的名称。                                                                                                                                     |
+| **link**  |                   `string`                    | 项目的链接。                                                                                                                                     |
+| **desc**  |                   `string`                    | <Badge type="tip" text="可选" /> 项目的描述。                                                                                                    |
+| **color** |                   `string`                    | <Badge type="tip" text="可选" /> 图标的颜色。                                                                                                    |
+| **icon**  |                   `string`                    | <Badge type="tip" text="可选" /> [iconify](https://icon-sets.iconify.design/) 或者 [fortawesome](https://fontawesome.com/search?o=r&m=free) 图标 |
+| **image** | `string` \| `{ light: string; dark: string }` | <Badge type="tip" text="可选" /> 支持单一图片地址或包含 light 和 dark 两种模式的对象                                                             |

--- a/packages/docs/guide/LinkCard.md
+++ b/packages/docs/guide/LinkCard.md
@@ -63,8 +63,15 @@ export default {
 ```
 
 **输出**
+
 <Box
-  :items="[
+:items="[
+    {
+    name: 'Home',
+    link: '/home',
+    icon: 'mdi:home',
+    color: '#4caf50',
+  },
     //使用FontAwesome图标 + 颜色
     { name: 'Vue.js', link: '', icon: 'fab fa-vuejs', color: '#4FC08D' },
     //使用FontAwesome图标 + 标签
@@ -88,18 +95,17 @@ export default {
     {
       name: 'GitHub',
       link: '',
-      icon: 'https://i.theojs.cn/logo/github.svg',
+      img: 'https://i.theojs.cn/logo/github.svg',
       tag: 'Github'
     },
     //使用自定义图标 + 深浅模式 + 标签
     {
       name: 'GitHub',
       link: '',
-      light: 'https://i.theojs.cn/logo/github.svg',
-      dark: 'https://i.theojs.cn/logo/github-dark.svg',
+      img: { light: 'https://i.theojs.cn/logo/github.svg', dark: 'https://i.theojs.cn/logo/github-dark.svg' },
       tag: 'Github'
     }
-  ]"
+]"
 />
 
 ### 参数说明

--- a/packages/docs/solis/DocTwikoo.md
+++ b/packages/docs/solis/DocTwikoo.md
@@ -6,7 +6,7 @@ title: 配置VitePress
   :items="[
     {
       name: '如何部署请查看 Twikoo 文档',
-      icon: 'https://twikoo.js.org/twikoo-logo-home.png',
+      image: 'https://twikoo.js.org/twikoo-logo-home.png',
       desc: '一个简洁、安全、免费的静态网站评论系统。',
       link: 'https://twikoo.js.org/quick-start.html'
     }

--- a/packages/docs/solis/getting-started.md
+++ b/packages/docs/solis/getting-started.md
@@ -6,7 +6,7 @@ title: 快速开始
   :items="[
     {
       name: '演示站点',
-      icon: 'https://i.theojs.cn/docs/202405101119004.png',
+      image: 'https://i.theojs.cn/docs/202405101119004.png',
       desc: 'VitePress的博客主题',
       link: 'https://share.theojs.cn/'
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@fortawesome/fontawesome-free':
         specifier: ^6.6.0
         version: 6.6.0
+      '@iconify/vue':
+        specifier: ^4.1.2
+        version: 4.1.2(vue@3.5.12(typescript@5.6.3))
       bumpp:
         specifier: ^9.8.1
         version: 9.8.1
@@ -419,6 +422,11 @@ packages:
 
   '@iconify/utils@2.1.33':
     resolution: {integrity: sha512-jP9h6v/g0BIZx0p7XGJJVtkVnydtbgTgt9mVNcGDYwaa7UhdHdI9dvoq+gKj9sijMSJKxUPEG2JyjsgXjxL7Kw==}
+
+  '@iconify/vue@4.1.2':
+    resolution: {integrity: sha512-CQnYqLiQD5LOAaXhBrmj1mdL2/NCJvwcC4jtW2Z8ukhThiFkLDkutarTOV2trfc9EXqUqRs0KqXOL9pZ/IyysA==}
+    peerDependencies:
+      vue: '>=3'
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
@@ -2046,6 +2054,11 @@ snapshots:
       mlly: 1.7.1
     transitivePeerDependencies:
       - supports-color
+
+  '@iconify/vue@4.1.2(vue@3.5.12(typescript@5.6.3))':
+    dependencies:
+      '@iconify/types': 2.0.0
+      vue: 3.5.12(typescript@5.6.3)
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 


### PR DESCRIPTION
**HomeFooter**

- support using Iconify icons
- beian adds `showIcon` attribute
- `group.style` and `link.style` support filling in color values ​​directly

view HomeFooter changes: https://tools.theojs.cn/guide/HomeFooter

**Box、Link、BoxCube**


- use Iconify and Fontawesome using the `icon` attribute.
- images no longer support the use of the `icon` attribute.
- the image uses the `image` attribute. ` string` | `{ light: string; dark: string }`

view Box、Link、BoxCube changes: https://tools.theojs.cn/guide/LinkCard 